### PR TITLE
Add viewholder lifecycle methods in InfinityAdapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ android:
     - tools
     - build-tools-25.0.2
     - android-25
+    - android-24
     - extra-android-support
     - extra-android-m2repository
     - sys-img-armeabi-v7a-android-24

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - android-25
     - extra-android-support
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-19
+    - sys-img-armeabi-v7a-android-24
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 
 before_script:
   - chmod +x gradlew
-  - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window -gpu off -no-boot-anim &
   - android-wait-for-emulator
   - adb shell settings put global window_animation_scale 0 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ android:
     - tools
     - build-tools-25.0.2
     - android-25
-    - android-24
     - extra-android-support
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-google_apis-24
 
 branches:
   only:
@@ -23,19 +21,12 @@ env:
 
 before_script:
   - chmod +x gradlew
-  - echo no | android create avd --force -n test -t android-24 --abi google_apis/armeabi-v7a
-  - emulator -avd test -no-window -gpu off -no-boot-anim &
-  - android-wait-for-emulator
-  - adb shell settings put global window_animation_scale 0 &
-  - adb shell settings put global transition_animation_scale 0 &
-  - adb shell settings put global animator_duration_scale 0 &
-  - adb shell input keyevent 82 &
-  
+
 install:
     - true
 
 script:
-  - TERM=dumb ./gradlew build -Dpre-dex=false :test:test connectedCheck
+  - TERM=dumb ./gradlew build -Dpre-dex=false
 
 after_failure: 
   - cat $TRAVIS_BUILD_DIR/app/build/outputs/lint-results-debug.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 before_script:
   - chmod +x gradlew
   - echo no | android create avd --force -n test -t android-24 --abi google_apis/armeabi-v7a
-  - emulator -avd test -no-audio -no-window -gpu off -no-boot-anim &
+  - emulator -avd test -no-window -gpu off -no-boot-anim &
   - android-wait-for-emulator
   - adb shell settings put global window_animation_scale 0 &
   - adb shell settings put global transition_animation_scale 0 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - android-24
     - extra-android-support
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-24
+    - sys-img-armeabi-v7a-google_apis-24
 
 branches:
   only:
@@ -23,7 +23,7 @@ env:
 
 before_script:
   - chmod +x gradlew
-  - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-24 --abi google_apis/armeabi-v7a
   - emulator -avd test -no-audio -no-window -gpu off -no-boot-anim &
   - android-wait-for-emulator
   - adb shell settings put global window_animation_scale 0 &

--- a/infinity/src/main/java/com/thefuntasty/infinity/InfinityAdapter.java
+++ b/infinity/src/main/java/com/thefuntasty/infinity/InfinityAdapter.java
@@ -229,7 +229,7 @@ public abstract class InfinityAdapter<T, VH extends RecyclerView.ViewHolder> ext
 	 *
 	 * @param holder footer ViewHolder
 	 */
-	protected void onFooterViewRecycler(FooterViewHolder holder) { }
+	protected void onFooterViewRecycled(FooterViewHolder holder) { }
 
 	/**
 	 * Provides footer ViewHolder when it gets attached to window
@@ -262,7 +262,7 @@ public abstract class InfinityAdapter<T, VH extends RecyclerView.ViewHolder> ext
 	@Override
 	public void onViewRecycled(VH holder) {
 		if (holder instanceof FooterViewHolder) {
-			onFooterViewRecycler((FooterViewHolder) holder);
+			onFooterViewRecycled((FooterViewHolder) holder);
 		} else {
 			onContentViewRecycled(holder);
 		}

--- a/infinity/src/main/java/com/thefuntasty/infinity/InfinityAdapter.java
+++ b/infinity/src/main/java/com/thefuntasty/infinity/InfinityAdapter.java
@@ -217,6 +217,78 @@ public abstract class InfinityAdapter<T, VH extends RecyclerView.ViewHolder> ext
 		return 0;
 	}
 
+	/**
+	 * Provides content ViewHolder before it gets recycled
+	 *
+	 * @param holder content ViewHolder
+	 */
+	protected void onContentViewRecycled(VH holder) { }
+
+	/**
+	 * Provides footer ViewHolder before it gets recycled
+	 *
+	 * @param holder footer ViewHolder
+	 */
+	protected void onFooterViewRecycler(FooterViewHolder holder) { }
+
+	/**
+	 * Provides footer ViewHolder when it gets attached to window
+	 *
+	 * @param holder footer ViewHolder
+	 */
+	protected void onFooterViewAttachedToWindow(FooterViewHolder holder) { }
+
+	/**
+	 * Provides content ViewHolder when it gets attached to window
+	 *
+	 * @param holder content ViewHolder
+	 */
+	protected void onContentViewAttachedToWindow(VH holder) { }
+
+	/**
+	 * Provides footer ViewHolder when it gets detached from window
+	 *
+	 * @param holder footer ViewHolder
+	 */
+	protected void onFooterViewDetachedFromWindow(FooterViewHolder holder) { }
+
+	/**
+	 * Provides content ViewHolder when it gets detached from window
+	 *
+	 * @param holder contentViewHolder
+	 */
+	protected void onContentViewDetachedFromWindow(VH holder) { }
+
+	@Override
+	public void onViewRecycled(VH holder) {
+		if (holder instanceof FooterViewHolder) {
+			onFooterViewRecycler((FooterViewHolder) holder);
+		} else {
+			onContentViewRecycled(holder);
+		}
+		super.onViewRecycled(holder);
+	}
+
+	@Override
+	public void onViewAttachedToWindow(VH holder) {
+		super.onViewAttachedToWindow(holder);
+		if (holder instanceof FooterViewHolder) {
+			onFooterViewAttachedToWindow((FooterViewHolder) holder);
+		} else {
+			onContentViewAttachedToWindow(holder);
+		}
+	}
+
+	@Override
+	public void onViewDetachedFromWindow(VH holder) {
+		super.onViewDetachedFromWindow(holder);
+		if (holder instanceof FooterViewHolder) {
+			onFooterViewDetachedFromWindow((FooterViewHolder) holder);
+		} else {
+			onContentViewDetachedFromWindow(holder);
+		}
+	}
+
 	private RecyclerView.ViewHolder onCreateFooterViewHolder(ViewGroup parent) {
 		View footer = LayoutInflater.from(parent.getContext()).inflate(getFooterLayout(), parent, false);
 		footer.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
#### Add ViewHolder lifecycle methods
- distinguish between content and footer ViewHolder lifecycle events - recycle, attach and detach (default RecyclerView.Adapter methods throw `ClassCastException` on footer ViewHolder, when overridden in `InfinityAdapter` implementation)